### PR TITLE
Fix double event listener in sidebar

### DIFF
--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -39,60 +39,31 @@ export default function Sidebar({ screen }: { screen: string }) {
 		getInitialState(previousBorderColor, isDesktop)
 	);
 
-	let mediaQuery: MediaQueryList;
+        useEffect(() => {
+                if (typeof window !== "undefined") {
+                        const mediaQuery = window.matchMedia("(min-width: 768px)");
+                        const handleMediaQueryChange = (e: MediaQueryListEvent) => {
+                                const isDesktop = e.matches;
+                                setInitialState(getInitialState(borderClasses[screen], isDesktop));
+                                setPreviousColorState(getInitialState(previousBorderColor, isDesktop));
+                        };
 
-	useEffect(() => {
-		if (typeof window !== "undefined") {
-			mediaQuery = window.matchMedia("(min-width: 768px)");
+                        // Set initial states correctly on first render
+                        setInitialState(
+                                getInitialState(borderClasses[screen], mediaQuery.matches)
+                        );
+                        setPreviousColorState(
+                                getInitialState(previousBorderColor, mediaQuery.matches)
+                        );
 
-			const handleMediaQueryChange = (e: MediaQueryListEvent) => {
-				const isDesktop = e.matches;
-				setInitialState(getInitialState(borderClasses[screen], isDesktop));
-				setPreviousColorState(getInitialState(previousBorderColor, isDesktop));
-			};
+                        // Listen for media query changes
+                        mediaQuery.addEventListener("change", handleMediaQueryChange);
 
-			// Set initial states correctly on first render
-			setInitialState(
-				getInitialState(borderClasses[screen], mediaQuery.matches)
-			);
-			setPreviousColorState(
-				getInitialState(previousBorderColor, mediaQuery.matches)
-			);
-
-			// Listen for media query changes
-			mediaQuery.addEventListener("change", handleMediaQueryChange);
-
-			return () => {
-				mediaQuery.removeEventListener("change", handleMediaQueryChange);
-			};
-		}
-	}, [screen, previousBorderColor]);
-
-	useEffect(() => {
-		let mediaQuery: MediaQueryList;
-
-		if (typeof window !== "undefined") {
-			mediaQuery = window.matchMedia("(min-width: 768px)");
-			isDesktop = mediaQuery.matches;
-
-			const handleMediaQueryChange = (e: MediaQueryListEvent) => {
-				const isDesktop = e.matches;
-				setInitialState(getInitialState(borderClasses[screen], isDesktop));
-				setPreviousColorState(getInitialState(previousBorderColor, isDesktop));
-			};
-
-			// Set initial states correctly on first render
-			setInitialState(getInitialState(borderClasses[screen], isDesktop));
-			setPreviousColorState(getInitialState(previousBorderColor, isDesktop));
-
-			// Listen for media query changes
-			mediaQuery.addEventListener("change", handleMediaQueryChange);
-
-			return () => {
-				mediaQuery.removeEventListener("change", handleMediaQueryChange);
-			};
-		}
-	}, [screen, previousBorderColor, isDesktop]);
+                        return () => {
+                                mediaQuery.removeEventListener("change", handleMediaQueryChange);
+                        };
+                }
+        }, [screen, previousBorderColor]);
 
 	return (
 		<motion.div


### PR DESCRIPTION
## Summary
- remove duplicate media query `useEffect` from sidebar component
- inline `mediaQuery` const inside remaining effect

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866a56d2e208326aa3bf21b4ec19fe3